### PR TITLE
fix PHPStan Error within PHP ^8.0 testing

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "codeigniter4/framework": "^4.0",
         "filp/whoops" : "^2"
     },


### PR DESCRIPTION
@agungsugiarto thank you for the whoops addon, This PR will fix PHPStan Error within PHP ^8.0 testing of my app where I'm using your addon.

```
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires agungsugiarto/codeigniter4-whoops ^1.0 -> satisfiable by agungsugiarto/codeigniter4-whoops[v1.0.0].
    - agungsugiarto/codeigniter4-whoops v1.0.0 requires php ^7.2 -> your php version (8.0.5) does not satisfy that requirement.
```